### PR TITLE
Limited menu options appear when a user removes all accounts

### DIFF
--- a/src/bankapp/Menu.java
+++ b/src/bankapp/Menu.java
@@ -42,8 +42,15 @@ public class Menu {
 	
 	public void operateMenu() {
 		while(active) {
-			provideUserChoices();
-			active = processUserInput(getUserInput());
+			if(user.getAccounts().isEmpty()) {
+				provideEmptyChoices();
+				active = processEmptyInput(getUserInput());
+			}
+			else {
+				provideUserChoices();
+				active = processUserInput(getUserInput());
+			}
+			
 		}
 	}
 	public void provideUserChoices(){
@@ -62,6 +69,17 @@ public class Menu {
 		System.out.println("(j) Change username");
 		System.out.println("(k) Change password");
     	System.out.println("(x) Logout");
+	}
+	
+	public void provideEmptyChoices() {
+		System.out.println();
+		System.out.println(" -- Welcome to Bear Banks! -- ");
+		System.out.println("Would you like to: ");
+		System.out.println("(a) Create a new account");
+		System.out.println("(b) Change username");
+		System.out.println("(c) Change password");
+    	System.out.println("(x) Logout");
+		
 	}
 
 	public String getUserInput(){
@@ -109,6 +127,26 @@ public class Menu {
 			default:
 				System.out.println("Invalid choice. Please try again.");
 				return true;
+		}
+	}
+	
+	public boolean processEmptyInput(String userInput) {
+		switch(userInput.toLowerCase()) {
+		case "a":
+			createAccount();
+			return true;
+		case "b":
+			changeUsername();
+			return true;
+		case "c":
+			changePassword();
+			return true;
+		case "x":
+			logout();
+			return false;
+		default:
+			System.out.println("Invalid choice. Please try again.");
+			return true;
 		}
 	}
 	


### PR DESCRIPTION
If a user deletes all of their accounts, then the menu will only let them create an account, change username, and change password. This can be updated with more menu options, such as changing user information found in issue https://github.com/CSE237SP25/project-latimore_thomas_weitzner/issues/50